### PR TITLE
allow booting Linode into rescue mode with more than 2 disks

### DIFF
--- a/linode/objects/linode/linode.py
+++ b/linode/objects/linode/linode.py
@@ -428,7 +428,7 @@ class Linode(Base):
 
     def rescue(self, *disks):
         if disks:
-            disks = { x: { 'disk_id': y } for x,y in zip(('sda','sdb'), disks) }
+            disks = { x: { 'disk_id': y } for x,y in zip(('sda','sdb','sdc','sdd','sde','sdf','sdg'), disks) }
         else:
             disks=None
 


### PR DESCRIPTION
Previously the call to `zip` would only zip to `/dev/sda` and
`/dev/sdb`, so if a Linode has more than 2 disks, only the first 2
specified would be mounted when booting into rescue mode. This expands
the call to `zip` to include each mountable device slot for rescue mode.

Seems to work as expected:
```
>>> l1.disks
PaginatedList (2 items)
>>> disks1
[17444995, 17444996]
>>> l1.rescue(*disks1)
{}
>>> l2.disks
PaginatedList (7 items)
>>> disks2
[17445035, 17445036, 17445039, 17445040, 17445045, 17445048, 17445211]
>>> l2.rescue(*disks2)
{}

# Finnix console on l1
root@ttyS0:~# lsblk
NAME   MAJ:MIN RM  SIZE RO TYPE MOUNTPOINT
sda      8:0    0 19.5G  0 disk
sdb      8:16   0  512M  0 disk
sdh      8:112  0  160M  1 disk
`-sdh1   8:113  0  160M  1 part
loop0    7:0    0  146M  1 loop /media/compressed_root

# Finnix console on l2
root@ttyS0:~# lsblk
NAME   MAJ:MIN RM  SIZE RO TYPE MOUNTPOINT
sda      8:0    0    1G  0 disk
sdb      8:16   0    1G  0 disk
sdc      8:32   0    1G  0 disk
sdd      8:48   0    2G  0 disk
sde      8:64   0    2G  0 disk
sdf      8:80   0    2G  0 disk
sdg      8:96   0   11G  0 disk
sdh      8:112  0  160M  1 disk
`-sdh1   8:113  0  160M  1 part
loop0    7:0    0  146M  1 loop /media/compressed_root
```